### PR TITLE
Ignore SSL errors

### DIFF
--- a/StoreLib/Services/MSHttpClient.cs
+++ b/StoreLib/Services/MSHttpClient.cs
@@ -13,11 +13,38 @@ namespace StoreLib.Services
     {
         private readonly CorrelationVector _cv = new CorrelationVector();
 
+        private static readonly bool IsWindows = System.Runtime.InteropServices.RuntimeInformation
+                                                    .IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows);
+        private static HttpClientHandler _handler
+        {
+            get
+            {
+                HttpClientHandler handler = new HttpClientHandler();
+                if (!IsWindows)
+                {
+                    handler.ServerCertificateCustomValidationCallback = ServerCertificateValidationCallback;
+                }
+                return handler;
+            }
+        }
+
+        private static bool ServerCertificateValidationCallback(
+            object sender,
+            System.Security.Cryptography.X509Certificates.X509Certificate certificate,
+            System.Security.Cryptography.X509Certificates.X509Chain chain,
+            System.Net.Security.SslPolicyErrors sslPolicyErrors
+        )
+        {
+
+            // TODO: Refine
+            return true;
+        }
+
         /// <summary>
         /// Instantiate MSHttpClient
         /// </summary>
         public MSHttpClient()
-            : base()
+            : base(_handler)
         {
             _cv.Init();
             base.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "StoreLib");


### PR DESCRIPTION
Non-Windows operating systems dont have the matching "Windows Update Server" certificates in the system-certificate-storage. Without those, certificate validation will fail.

This implements a hack that simply ignores the SSL errors.