### PR TITLE
Fix NullReferenceException for empty package

### DIFF
--- a/StoreLib.Cli/CommandHandler.cs
+++ b/StoreLib.Cli/CommandHandler.cs
@@ -107,7 +107,7 @@ namespace StoreLib.Cli
             if (props.Packages.Count == 0 ||
                 props.Packages[0].PackageDownloadUris == null)
             {
-                Console.WriteLine("Packages.Count == 0");
+                return;
             }
 
             foreach (var Package in props.Packages[0].PackageDownloadUris)


### PR DESCRIPTION
Fixes
```
Packages.Count == 0
System.Collections.Generic.List`1[StoreLib.Models.Package]
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at StoreLib.Cli.CommandHandler.PackagesAsync(DisplayCatalogHandler dcatHandler, String id, IdentiferType type) in StoreLib\StoreLib.Cli\CommandHandler.cs:line 114
   at StoreLib.Cli.Program.Run(Options opts) in StoreLib\StoreLib.Cli\Program.cs:line 88
   at CommandLine.ParserResultExtensions.WithParsed[T](ParserResult`1 result, Action`1 action)
   at StoreLib.Cli.Program.Main(String[] args) in StoreLib\StoreLib.Cli\Program.cs:line 60
```